### PR TITLE
make path to track.ui relative to the track executable

### DIFF
--- a/track
+++ b/track
@@ -4,6 +4,7 @@
 import sys
 import signal
 import logging
+import os.path
 
 import track_qt
 
@@ -23,7 +24,7 @@ class track_ui(QtGui.QMainWindow):
     def __init__(self):
         super(track_ui, self).__init__()
         self._tracker = track_qt.time_tracker(self)
-
+        self.directory = os.path.dirname(os.path.realtpath(__file__))
         self._tracker.load()
 
         self.initUI()
@@ -43,7 +44,8 @@ class track_ui(QtGui.QMainWindow):
         self.show()
 
     def initUI(self):
-        uic.loadUi('track.ui', self)
+        trackui_path = os.path.join(self.directory, 'track.ui')
+        uic.loadUi(trackui_path, self)
 
         self.setGeometry(300, 0, 700, 680)  # todo: maximize vertically
         self.setWindowTitle('Track')


### PR DESCRIPTION
After this edit, it is possible to start track from e.g. home directory (or any script) using full path:
`/home/user/workspace/track/track &`
Should also allow starting `track` using symlinks and PATH mechanism.
Before this edit, starting `track` from anywhere outside its directory would fail with `IOError: [Errno 2] No such file or directory: 'track.ui'`

This edit does not address the location of .json data files: they will be loaded/saved from/to the current directory... It might be a good idea to have a `.track` directory in ~/, where to store all the JSON files?
